### PR TITLE
TTVFast handles errors correctly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/TTVFast"]
 	path = external/TTVFast
-	url = https://github.com/kdeck/TTVFast.git
+	url = https://github.com/mindriot101/TTVFast-python-compat.git

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TOXARGS ?=
+
 all: help
 
 help:
@@ -7,7 +9,7 @@ help:
 	@echo "- package"
 
 test:
-	py.test testing
+	tox $(TOXARGS)
 
 coverage:
 	py.test --cov ttvfast --cov-report html testing


### PR DESCRIPTION
When an error in the underlying `TTVFast` library occurs, the process exits which is not noticeable by the python interpreter, and causes issues when running under `emcee`.

This change:
- swaps the underlying `TTVFast` library for [my fork](https://github.com/mindriot101/TTVFast-python-compat) which conveys errors through an error state enum rather than just exiting uncleanly
- handles the errors in the python module wrapper file to raise a Python exception

I've submitted the first change to upstream, and if/when they merge I shall change the submodule back to keep consistency.
